### PR TITLE
Change build URL to public GitHub repo.

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -40,7 +40,6 @@ jobs:
       - name: Build Docker Image
         run: |
           docker build \
-            --build-arg GITLAB_TOKEN='${{ secrets.GITLAB_TOKEN }}' \
             --tag "ghcr.io/simplyedit/simplycode-docker:${{ env.TAG }}" \
           .
           docker push "ghcr.io/simplyedit/simplycode-docker:${{ env.TAG }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,17 @@
 FROM php:7.4-apache as builder
 
-ARG GITLAB_TOKEN
-ENV GITLAB_TOKEN="${GITLAB_TOKEN?}"
-
 RUN apt-get update && apt-get install -y git ssl-cert \
     && git clone 'https://github.com/SimplyEdit/simply-edit-backend.git' /app/simply-edit-backend \
-    && git clone "https://token:${GITLAB_TOKEN}@gitlab.muze.nl/muze/simply-code.git" /app/simply-code
+    && git clone 'https://github.com/SimplyEdit/simplycode.git' /app/simplycode
 
 FROM php:7.4-apache
 
-COPY --from=builder /app/simply-code/lib /var/www/lib
-COPY --from=builder /app/simply-code/www/api/.htaccess /var/www/html/api/.htaccess
-COPY --from=builder /app/simply-code/www/api/data/generated.html /var/www/html/simplycode/index.html
-COPY --from=builder /app/simply-code/www/api/index.php /var/www/html/api/index.php
-COPY --from=builder /app/simply-code/www/css /var/www/html/simplycode/css
-COPY --from=builder /app/simply-code/www/js /var/www/html/simplycode/js
+COPY --from=builder /app/simplycode/lib /var/www/lib
+COPY --from=builder /app/simplycode/www/api/.htaccess /var/www/html/api/.htaccess
+COPY --from=builder /app/simplycode/www/api/data/generated.html /var/www/html/simplycode/index.html
+COPY --from=builder /app/simplycode/www/api/index.php /var/www/html/api/index.php
+COPY --from=builder /app/simplycode/www/css /var/www/html/simplycode/css
+COPY --from=builder /app/simplycode/www/js /var/www/html/simplycode/js
 
 COPY --from=builder /app/simply-edit-backend /var/www/html/simplycode/simplyedit
 


### PR DESCRIPTION
Once https://github.com/SimplyEdit/simplycode/pull/2 has been merged, this MR can be merged to use the public GitHub repo instead of the private GitLab one.