### PR TITLE
Remove SimplyEdit Backend as it is not used

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@ ARG GITLAB_TOKEN
 ENV GITLAB_TOKEN="${GITLAB_TOKEN?}"
 
 RUN apt-get update && apt-get install -y git ssl-cert \
-    && git clone 'https://github.com/SimplyEdit/simply-edit-backend.git' /app/simply-edit-backend \
     && git clone "https://token:${GITLAB_TOKEN}@gitlab.muze.nl/muze/simply-code.git" /app/simply-code
 
 FROM php:7.4-apache
@@ -15,9 +14,6 @@ COPY --from=builder /app/simply-code/www/api/data/generated.html /var/www/html/s
 COPY --from=builder /app/simply-code/www/api/index.php /var/www/html/api/index.php
 COPY --from=builder /app/simply-code/www/css /var/www/html/simplycode/css
 COPY --from=builder /app/simply-code/www/js /var/www/html/simplycode/js
-
-COPY --from=builder /app/simply-edit-backend /var/www/html/simplycode/simplyedit
-
 COPY --from=builder /etc/ssl/certs/ssl-cert-snakeoil.pem /etc/ssl/certs/ssl-cert-snakeoil.pem
 COPY --from=builder /etc/ssl/private/ssl-cert-snakeoil.key /etc/ssl/private/ssl-cert-snakeoil.key
 


### PR DESCRIPTION
The full tree of this repository looks like this:

```
├── lib/
└── www/
    ├── api/
    │   └── data/
    ├── css/
    ├── data/
    ├── js/
    ├── simply-edit/
    └── templates/
```

The part we are currently interested in is where HTTP requests go:

```
  ├── lib/
  │   ├── config.php ─────────╮   ◀───╮
  │   ├── filesystem.php  ◀───┤       │
  │   ├── http.php        ◀───╯       │
  │   └── router.php                  │ require_once
  └── www/                            │
      ├── api/          ─╖            │
      │   ├── data/      ║ .htaccess  │
      │   └── index.php ─╨────────────╯
      ├── simply-edit/      ──╖
      │   ├── config.php      ║
      │   ├── filesystem.php  ║
      │   ├── http.php        ║ .htaccess
      │   ├── index.php       ║
      │   ├── router.php  ◁───╢
      │   └── store.php       ║
      ├── templates/        ──╜
      ├── generated.html -> api/data/generated.html
      └── index.html
```

Anything under `www/` would normally be handled by the `index.php` (for `/`) or `router.php` (for everything else).

But the `index.html` overwrites the `index.php` and `api/` has its own `.htaccess`.

So it looks like the only config, filesystem, and router actually in use are those in `lib/`.