### PR TITLE
Add more friendly entry into SimplyCode Docker for new users.

### DIFF
--- a/000-default.conf
+++ b/000-default.conf
@@ -9,6 +9,7 @@
     DocumentRoot /var/www/html
     ErrorLog ${APACHE_LOG_DIR}/error.log
     CustomLog ${APACHE_LOG_DIR}/access.log combined
+    ErrorDocument 403 /403.php
 </VirtualHost>
 
 <VirtualHost *:443>
@@ -16,6 +17,7 @@
     DocumentRoot /var/www/html
     ErrorLog ${APACHE_LOG_DIR}/error.log
     CustomLog ${APACHE_LOG_DIR}/access.log combined
+    ErrorDocument 403 /403.php
 
     SSLEngine on
     SSLCertificateFile      /etc/ssl/certs/ssl-cert-snakeoil.pem

--- a/403.php
+++ b/403.php
@@ -1,0 +1,116 @@
+<?php
+
+$volume = listVolumeContent();
+$templateValues = [
+    $_SERVER['SERVER_SIGNATURE'],
+    getenv('USER_ID') . ':' . getenv('USER_GID'),
+    exec('whoami'),
+    implode('</code></li><li><code>', $volume),
+];
+
+$responseCode = 403;
+$template = <<<'HTML'
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
+<html lang="en">
+<head>
+  <title>403 Forbidden</title>
+</head>
+<body>
+  <h1>Forbidden</h1>
+  <p>You don't have permission to access this resource.</p>
+  <hr>
+  %s
+  <hr>
+  <details>
+    <summary>Technical details</summary>
+    <h2>Technical details</h2>
+    <p>uid/gid: <code>%s</code></p>
+    <p>user: <code>%s</code></p>
+    <p>Volume contents:</p>
+    <ul>
+      <li><code>%s</code></li>
+    </ul>
+  </details>
+</body>
+</html>
+HTML;
+
+function listVolumeContent(): array
+{
+    $files = [];
+    $folders = [];
+
+    $iterator = new FilesystemIterator(
+        '/var/www/www/api/data/',
+        FilesystemIterator::SKIP_DOTS | FilesystemIterator::KEY_AS_FILENAME
+    );
+
+    foreach ($iterator as $file) {
+        $type = $file->getType();
+        switch ($type) {
+            case 'dir':
+                $filename = $file->getFilename() . '/';
+                $folders[] = $filename;
+                break;
+            case 'link':
+                $filename = $file->getFilename() . ' -> ' . readlink($file->getPathname());
+                $files[] = $filename;
+                break;
+            case 'file':
+            default:
+                $filename = $file->getFilename();
+                $files[] = $filename;
+                break;
+        }
+    }
+
+    sort($folders);
+    sort($files);
+
+    return array_merge($folders, $files);
+}
+
+if (
+    $_SERVER['REQUEST_URI'] === '/' && ! file_exists('/var/www/www/api/data/generated.html')
+) {
+    $responseCode = 200;
+    $template = <<<'HTML'
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
+<html lang="en">
+<head>
+  <title>Welcome to SimplyCode</title>
+</head>
+<body>
+  <h1>Welcome to SimplyCode!</h1>
+  <p>
+    This looks like your first visit.
+    <strong>Go to <a href="%s">%s</a> to start building something awesome.</strong>
+  </p>
+  <hr>
+  %s
+  <hr>
+  <details>
+    <summary>Technical details</summary>
+    <h2>Technical details</h2>
+    <p>uid/gid: <code>%s</code></p>
+    <p>user: <code>%s</code></p>
+    <p>Volume contents:</p>
+    <ul>
+      <li><code>%s</code></li>
+    </ul>
+  </details>
+</body>
+</html>
+HTML;
+    $templateValues = array_merge([],
+        [
+        "{$_SERVER['REQUEST_SCHEME']}://{$_SERVER['SERVER_NAME']}:{$_SERVER['SERVER_PORT']}/simplycode",
+        '/simplycode',
+        ],
+        $templateValues
+    );
+}
+
+http_response_code($responseCode);
+header('Content-Type: text/html');
+vprintf($template, $templateValues);

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ COPY --from=builder /etc/ssl/private/ssl-cert-snakeoil.key /etc/ssl/private/ssl-
 
 COPY 000-default.conf /etc/apache2/sites-available/000-default.conf
 COPY entrypoint.sh /entrypoint.sh
+COPY 403.php /var/www/html/403.php
 
 RUN a2enmod --quiet rewrite ssl headers \
     && chmod +x /entrypoint.sh \


### PR DESCRIPTION
This MR adds a few changes to make it easier for new users to understand what is going on.

First of all, the `/var/www/www/api/data/generated.html` file missing is not an error, but a warning.

In case it is missing the `/simplycode` path is added to the URL shown in the docker output.

Secondly, a custom 403 handler is added.

If the path is `/` and `/var/www/www/api/data/generated.html` is missing, a custom message is shown which directs the user to `/simplycode`.

This code is a fisrt working draft, and can be improved upon later. 

Finally, the contents of `/var/www/www/api/data` are now always shown, both in the docker output and on the 403 page.

This should make it easier to debug what is going on in case of the wrong directory being mounted into the docker container.

These changes can be tested using:

```
docker pull ghcr.io/simplyedit/simplycode-docker:7_merge
docker run -it --rm --env "USER_ID=$(id -u)" --env "USER_GID=$(id -g)" --volume "${PWD}:/var/www/www/api/data" ghcr.io/simplyedit/simplycode-docker:7_merge
```

Leave out the `--volume` to emulate a clean install by a new user.