### PR TITLE
Add headers to apache config to allow CORS.

### DIFF
--- a/000-default.conf
+++ b/000-default.conf
@@ -2,6 +2,8 @@
     Options Indexes FollowSymLinks
     AllowOverride All
     Require all granted
+
+    Header set Access-Control-Allow-Origin "*"
 </Directory>
 
 <VirtualHost *:80>


### PR DESCRIPTION
This MR adds headers to the Apache config to allow including files from another location.

The original use-case is to allow including components from one SimplyCode instance in another, specifically in development.